### PR TITLE
Fix glass theme layout collapse on older iOS Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "jsdom": "^27.0.0",
         "lint-staged": "^16.2.3",
         "playwright": "1.61.1",
-        "postcss": "^8.5.6",
+        "postcss": "8.5.16",
         "prettier": "^3.7.3",
         "prettier-plugin-tailwindcss": "^0.7.1",
         "tailwindcss": "^4.1.14",
@@ -11353,9 +11353,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -12017,9 +12017,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",
@@ -12036,7 +12036,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "husky": "^9.1.7",
         "jsdom": "^27.0.0",
         "lint-staged": "^16.2.3",
-        "playwright": "1.61.1",
         "postcss": "8.5.16",
         "prettier": "^3.7.3",
         "prettier-plugin-tailwindcss": "^0.7.1",
@@ -11957,53 +11956,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.61.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "husky": "^9.1.7",
         "jsdom": "^27.0.0",
         "lint-staged": "^16.2.3",
+        "playwright": "1.61.1",
         "postcss": "^8.5.6",
         "prettier": "^3.7.3",
         "prettier-plugin-tailwindcss": "^0.7.1",
@@ -11956,6 +11957,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "npm run build &&npm run worker:watch & next dev",
-    "build": "npm run build:worker && next build",
+    "build": "npm run build:worker && next build && node scripts/flatten-css-layers.mjs",
     "prebuild": "npm run format:fix",
     "start": "next start",
     "lint": "eslint . --fix",
@@ -90,6 +90,7 @@
     "husky": "^9.1.7",
     "jsdom": "^27.0.0",
     "lint-staged": "^16.2.3",
+    "playwright": "1.61.1",
     "postcss": "^8.5.6",
     "prettier": "^3.7.3",
     "prettier-plugin-tailwindcss": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "jsdom": "^27.0.0",
     "lint-staged": "^16.2.3",
     "playwright": "1.61.1",
-    "postcss": "^8.5.6",
+    "postcss": "8.5.16",
     "prettier": "^3.7.3",
     "prettier-plugin-tailwindcss": "^0.7.1",
     "tailwindcss": "^4.1.14",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "husky": "^9.1.7",
     "jsdom": "^27.0.0",
     "lint-staged": "^16.2.3",
-    "playwright": "1.61.1",
     "postcss": "8.5.16",
     "prettier": "^3.7.3",
     "prettier-plugin-tailwindcss": "^0.7.1",

--- a/scripts/flatten-css-layers.mjs
+++ b/scripts/flatten-css-layers.mjs
@@ -8,55 +8,63 @@
  * rules out of their layers preserves precedence via source order and makes
  * the stylesheet work on any engine.
  *
- * Runs after `next build` (see the build script in package.json).
+ * Runs after `next build` (see the build script in package.json). This is a
+ * best-effort compatibility pass: it must NEVER fail the build — a layered
+ * stylesheet still works everywhere except old Safari — so every failure
+ * path warns and exits 0.
  */
 /* eslint-disable no-console -- build-time script, console output is its UI */
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import postcss from "postcss";
 
-const cssDir = join(process.cwd(), ".next", "static", "css");
+const main = async () => {
+  const { readdirSync, readFileSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { default: postcss } = await import("postcss");
 
-const unwrap = (root) => {
-  // Re-walk until stable: replacing an at-rule with its children can insert
-  // nested `@layer` blocks the current walk pass does not visit.
-  for (;;) {
-    let found = false;
-    root.walkAtRules("layer", (atRule) => {
-      found = true;
-      if (atRule.nodes && atRule.nodes.length > 0) {
-        atRule.replaceWith(atRule.nodes);
-      } else {
-        atRule.remove(); // bare `@layer a, b;` statements
-      }
-    });
-    if (!found) break;
+  const cssDir = join(process.cwd(), ".next", "static", "css");
+
+  const unwrap = (root) => {
+    // Re-walk until stable: replacing an at-rule with its children can insert
+    // nested `@layer` blocks the current walk pass does not visit.
+    for (;;) {
+      let found = false;
+      root.walkAtRules("layer", (atRule) => {
+        found = true;
+        if (atRule.nodes && atRule.nodes.length > 0) {
+          atRule.replaceWith(atRule.nodes);
+        } else {
+          atRule.remove(); // bare `@layer a, b;` statements
+        }
+      });
+      if (!found) break;
+    }
+  };
+
+  let files = [];
+  try {
+    files = readdirSync(cssDir).filter((f) => f.endsWith(".css"));
+  } catch {
+    console.log("flatten-css-layers: no CSS output directory, skipping");
+    return;
+  }
+
+  for (const file of files) {
+    try {
+      const path = join(cssDir, file);
+      const css = readFileSync(path, "utf8");
+      const result = postcss.parse(css, { from: path });
+      unwrap(result);
+      const flattened = result.toString();
+      writeFileSync(path, flattened);
+      const layersLeft = (flattened.match(/@layer/g) || []).length;
+      console.log(
+        `flatten-css-layers: ${file} ${css.length} -> ${flattened.length} bytes, @layer left: ${layersLeft}`
+      );
+    } catch (error) {
+      console.warn(`flatten-css-layers: skipped ${file}: ${error}`);
+    }
   }
 };
 
-let files = [];
-try {
-  files = readdirSync(cssDir).filter((f) => f.endsWith(".css"));
-} catch {
-  console.log("flatten-css-layers: no CSS output directory, skipping");
-  process.exit(0);
-}
-
-for (const file of files) {
-  try {
-    const path = join(cssDir, file);
-    const css = readFileSync(path, "utf8");
-    const result = postcss.parse(css, { from: path });
-    unwrap(result);
-    const flattened = result.toString();
-    writeFileSync(path, flattened);
-    const layersLeft = (flattened.match(/@layer/g) || []).length;
-    console.log(
-      `flatten-css-layers: ${file} ${css.length} -> ${flattened.length} bytes, @layer left: ${layersLeft}`
-    );
-  } catch (error) {
-    // Never fail the deploy over the compatibility pass — a layered
-    // stylesheet still works everywhere except old Safari.
-    console.warn(`flatten-css-layers: skipped ${file}: ${error}`);
-  }
-}
+main().catch((error) => {
+  console.warn(`flatten-css-layers: skipped entirely: ${error}`);
+});

--- a/scripts/flatten-css-layers.mjs
+++ b/scripts/flatten-css-layers.mjs
@@ -43,14 +43,20 @@ try {
 }
 
 for (const file of files) {
-  const path = join(cssDir, file);
-  const css = readFileSync(path, "utf8");
-  const result = postcss.parse(css, { from: path });
-  unwrap(result);
-  const flattened = result.toString();
-  writeFileSync(path, flattened);
-  const layersLeft = (flattened.match(/@layer/g) || []).length;
-  console.log(
-    `flatten-css-layers: ${file} ${css.length} -> ${flattened.length} bytes, @layer left: ${layersLeft}`
-  );
+  try {
+    const path = join(cssDir, file);
+    const css = readFileSync(path, "utf8");
+    const result = postcss.parse(css, { from: path });
+    unwrap(result);
+    const flattened = result.toString();
+    writeFileSync(path, flattened);
+    const layersLeft = (flattened.match(/@layer/g) || []).length;
+    console.log(
+      `flatten-css-layers: ${file} ${css.length} -> ${flattened.length} bytes, @layer left: ${layersLeft}`
+    );
+  } catch (error) {
+    // Never fail the deploy over the compatibility pass — a layered
+    // stylesheet still works everywhere except old Safari.
+    console.warn(`flatten-css-layers: skipped ${file}: ${error}`);
+  }
 }

--- a/scripts/flatten-css-layers.mjs
+++ b/scripts/flatten-css-layers.mjs
@@ -10,6 +10,7 @@
  *
  * Runs after `next build` (see the build script in package.json).
  */
+/* eslint-disable no-console -- build-time script, console output is its UI */
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import postcss from "postcss";

--- a/scripts/flatten-css-layers.mjs
+++ b/scripts/flatten-css-layers.mjs
@@ -1,0 +1,55 @@
+/**
+ * Unwrap CSS cascade layers from the built stylesheets.
+ *
+ * Tailwind v4 wraps everything in `@layer` blocks. Browsers that mishandle
+ * cascade layers (older iOS Safari) then drop every utility while unlayered
+ * rules keep applying, collapsing the whole layout. Tailwind's output is
+ * already ordered properties -> theme -> base -> utilities, so hoisting the
+ * rules out of their layers preserves precedence via source order and makes
+ * the stylesheet work on any engine.
+ *
+ * Runs after `next build` (see the build script in package.json).
+ */
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import postcss from "postcss";
+
+const cssDir = join(process.cwd(), ".next", "static", "css");
+
+const unwrap = (root) => {
+  // Re-walk until stable: replacing an at-rule with its children can insert
+  // nested `@layer` blocks the current walk pass does not visit.
+  for (;;) {
+    let found = false;
+    root.walkAtRules("layer", (atRule) => {
+      found = true;
+      if (atRule.nodes && atRule.nodes.length > 0) {
+        atRule.replaceWith(atRule.nodes);
+      } else {
+        atRule.remove(); // bare `@layer a, b;` statements
+      }
+    });
+    if (!found) break;
+  }
+};
+
+let files = [];
+try {
+  files = readdirSync(cssDir).filter((f) => f.endsWith(".css"));
+} catch {
+  console.log("flatten-css-layers: no CSS output directory, skipping");
+  process.exit(0);
+}
+
+for (const file of files) {
+  const path = join(cssDir, file);
+  const css = readFileSync(path, "utf8");
+  const result = postcss.parse(css, { from: path });
+  unwrap(result);
+  const flattened = result.toString();
+  writeFileSync(path, flattened);
+  const layersLeft = (flattened.match(/@layer/g) || []).length;
+  console.log(
+    `flatten-css-layers: ${file} ${css.length} -> ${flattened.length} bytes, @layer left: ${layersLeft}`
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,17 +28,12 @@
   color: var(--ink-faint);
 }
 
-/* Pastel liquid backdrop: lavender / pink / ice blue, slowly drifting. */
+/* Pastel liquid backdrop: lavender / pink / ice blue, slowly drifting.
+ * The gradients live on a fixed pseudo-element instead of the body with
+ * background-attachment: fixed, which iOS Safari does not render. */
 .liquid-bg {
   position: relative;
   background-color: #e9e6f4;
-  background-image:
-    radial-gradient(90rem 60rem at 12% -10%, rgba(214, 197, 245, 0.9), transparent 60%),
-    radial-gradient(80rem 55rem at 95% 15%, rgba(247, 213, 231, 0.85), transparent 60%),
-    radial-gradient(70rem 60rem at 30% 85%, rgba(197, 226, 246, 0.9), transparent 62%),
-    radial-gradient(60rem 50rem at 80% 95%, rgba(233, 204, 239, 0.7), transparent 65%),
-    linear-gradient(160deg, #efe9f6 0%, #ece6f5 40%, #e3e9f5 100%);
-  background-attachment: fixed;
 }
 
 .liquid-bg::before {
@@ -49,7 +44,12 @@
   pointer-events: none;
   background:
     radial-gradient(32rem 26rem at 25% 30%, rgba(255, 255, 255, 0.5), transparent 70%),
-    radial-gradient(38rem 30rem at 75% 65%, rgba(255, 245, 255, 0.45), transparent 70%);
+    radial-gradient(38rem 30rem at 75% 65%, rgba(255, 245, 255, 0.45), transparent 70%),
+    radial-gradient(90rem 60rem at 12% -10%, rgba(214, 197, 245, 0.9), transparent 60%),
+    radial-gradient(80rem 55rem at 95% 15%, rgba(247, 213, 231, 0.85), transparent 60%),
+    radial-gradient(70rem 60rem at 30% 85%, rgba(197, 226, 246, 0.9), transparent 62%),
+    radial-gradient(60rem 50rem at 80% 95%, rgba(233, 204, 239, 0.7), transparent 65%),
+    linear-gradient(160deg, #efe9f6 0%, #ece6f5 40%, #e3e9f5 100%);
   animation: liquid-drift 26s ease-in-out infinite alternate;
 }
 


### PR DESCRIPTION
## Summary

After the glass theme deploy, some iOS Safari versions rendered the site as unstyled stacked markup: Tailwind v4 wraps every utility in `@layer` blocks, and engines that mishandle cascade layers drop all of them while unlayered rules keep applying — collapsing the layout while the custom glass classes still worked.

- **Flatten cascade layers** out of the built stylesheets in a post-build step (`scripts/flatten-css-layers.mjs`, wired into `npm run build`, so Vercel runs it). Tailwind's output order already encodes layer precedence, so hoisting rules preserves the cascade and works on any engine — verified zero `@layer` remaining in all emitted CSS
- **Fix the pastel backdrop on iOS**: `background-attachment: fixed` isn't rendered by iOS Safari, so the liquid gradients moved onto the fixed `::before` element

## Verification

- Flattened build renders pixel-identical in WebKit (iPhone viewport) and Chromium (desktop): glass hero, nav, sections all correct; Tailwind utility probe (`.w-4`, `.hidden`, `--spacing`) passes
- Type check, unit tests, and production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB)_