### PR TITLE
Make the liquid glass theme truly transparent like the reference

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,8 +12,8 @@
   --ink-faint: #8494b3; /* tertiary text */
   --accent: #8b5cf6; /* violet accent */
   --accent-soft: #b9a5f9;
-  --glass-border: rgba(255, 255, 255, 0.65);
-  --glass-highlight: rgba(255, 255, 255, 0.85);
+  --glass-border: rgba(255, 255, 255, 0.55);
+  --glass-highlight: rgba(255, 255, 255, 0.95);
 }
 
 .text-ink {
@@ -33,7 +33,7 @@
  * background-attachment: fixed, which iOS Safari does not render. */
 .liquid-bg {
   position: relative;
-  background-color: #e9e6f4;
+  background-color: #e4def2;
 }
 
 .liquid-bg::before {
@@ -44,12 +44,13 @@
   pointer-events: none;
   background:
     radial-gradient(32rem 26rem at 25% 30%, rgba(255, 255, 255, 0.5), transparent 70%),
-    radial-gradient(38rem 30rem at 75% 65%, rgba(255, 245, 255, 0.45), transparent 70%),
-    radial-gradient(90rem 60rem at 12% -10%, rgba(214, 197, 245, 0.9), transparent 60%),
-    radial-gradient(80rem 55rem at 95% 15%, rgba(247, 213, 231, 0.85), transparent 60%),
-    radial-gradient(70rem 60rem at 30% 85%, rgba(197, 226, 246, 0.9), transparent 62%),
-    radial-gradient(60rem 50rem at 80% 95%, rgba(233, 204, 239, 0.7), transparent 65%),
-    linear-gradient(160deg, #efe9f6 0%, #ece6f5 40%, #e3e9f5 100%);
+    radial-gradient(38rem 30rem at 75% 65%, rgba(255, 240, 252, 0.45), transparent 70%),
+    radial-gradient(90rem 60rem at 12% -10%, rgba(188, 160, 243, 0.95), transparent 62%),
+    radial-gradient(80rem 55rem at 95% 15%, rgba(250, 186, 222, 0.95), transparent 62%),
+    radial-gradient(70rem 60rem at 30% 85%, rgba(153, 208, 247, 0.95), transparent 64%),
+    radial-gradient(60rem 50rem at 80% 95%, rgba(222, 173, 240, 0.9), transparent 66%),
+    radial-gradient(44rem 22rem at 55% 48%, rgba(255, 189, 214, 0.4), transparent 70%),
+    linear-gradient(160deg, #ebe1f7 0%, #e5dcf5 40%, #d8e4f7 100%);
   animation: liquid-drift 26s ease-in-out infinite alternate;
 }
 
@@ -68,50 +69,107 @@
   }
 }
 
-/* Frosted glass surface — panels, cards, sheets. */
+/* Transparent bubble glass — panels, cards, sheets. The slab reads as real
+ * glass: a see-through fill with a diagonal specular streak, a bright
+ * refractive rim (inset bevels on every edge), an interior glow suggesting
+ * thickness, and a soft drop shadow lifting it off the backdrop. */
 .glass-panel {
   border: 1px solid var(--glass-border);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0.3));
-  backdrop-filter: blur(18px) saturate(150%);
-  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  background: linear-gradient(
+    115deg,
+    rgba(255, 255, 255, 0.4) 0%,
+    rgba(255, 255, 255, 0.1) 34%,
+    rgba(255, 255, 255, 0.04) 62%,
+    rgba(255, 255, 255, 0.24) 100%
+  );
+  -webkit-backdrop-filter: blur(22px) saturate(180%);
+  backdrop-filter: blur(22px) saturate(180%);
   box-shadow:
-    0 20px 45px -22px rgba(103, 110, 176, 0.45),
-    inset 0 1px 0 var(--glass-highlight);
+    inset 0 1px 1px var(--glass-highlight),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.5),
+    inset 1.5px 0 1px -0.5px rgba(255, 255, 255, 0.55),
+    inset -1.5px 0 1px -0.5px rgba(255, 255, 255, 0.55),
+    inset 0 0 28px rgba(255, 255, 255, 0.14),
+    0 24px 48px -20px rgba(97, 94, 166, 0.4),
+    0 6px 16px -8px rgba(97, 94, 166, 0.25);
 }
 
-/* Near-opaque glass — for stacked sticky cards where translucency would let
- * the card underneath bleed through. */
+/* Milkier glass — for stacked sticky cards where full translucency would let
+ * the card underneath bleed through. Same rim and sheen, denser fill. */
 .glass-panel-solid {
   border: 1px solid var(--glass-border);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.985), rgba(249, 247, 255, 0.96));
-  backdrop-filter: blur(18px) saturate(150%);
-  -webkit-backdrop-filter: blur(18px) saturate(150%);
+  /* Fully opaque: these cards stack on scroll, and any alpha at all lets the
+   * card underneath ghost through. The glass look comes from the rim + sheen. */
+  background: linear-gradient(115deg, #ffffff 0%, #fdfcff 40%, #faf8ff 70%, #fefeff 100%);
+  /* Cards can carry both .glass-panel and .glass-panel-solid (Card.tsx bakes
+   * the former in); a backdrop blur on a near-opaque stacked card composites
+   * the card underneath through — force it off. */
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   box-shadow:
-    0 20px 45px -22px rgba(103, 110, 176, 0.45),
-    inset 0 1px 0 var(--glass-highlight);
+    inset 0 1px 1px var(--glass-highlight),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.5),
+    inset 0 0 28px rgba(255, 255, 255, 0.16),
+    0 24px 48px -20px rgba(97, 94, 166, 0.4),
+    0 6px 16px -8px rgba(97, 94, 166, 0.25);
 }
 
-/* Frosted glass pill — nav bars, badges, secondary buttons. */
+/* Transparent glass pill — nav bars, badges, secondary buttons. */
 .glass-pill {
   border-radius: 9999px;
   border: 1px solid var(--glass-border);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.66), rgba(255, 255, 255, 0.34));
-  backdrop-filter: blur(14px) saturate(150%);
-  -webkit-backdrop-filter: blur(14px) saturate(150%);
+  background: linear-gradient(
+    115deg,
+    rgba(255, 255, 255, 0.48) 0%,
+    rgba(255, 255, 255, 0.16) 45%,
+    rgba(255, 255, 255, 0.3) 100%
+  );
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  backdrop-filter: blur(16px) saturate(180%);
   box-shadow:
-    0 12px 28px -16px rgba(103, 110, 176, 0.45),
-    inset 0 1px 0 var(--glass-highlight);
+    inset 0 1px 1px var(--glass-highlight),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.45),
+    inset 0 0 14px rgba(255, 255, 255, 0.16),
+    0 12px 28px -14px rgba(97, 94, 166, 0.45);
 }
 
-/* Violet accent pill — primary call-to-action, like the reference "Button". */
+/* Glass chrome — fixed header bar and other full-width sheets. */
+.glass-chrome {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.55);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.12));
+  -webkit-backdrop-filter: blur(24px) saturate(170%);
+  backdrop-filter: blur(24px) saturate(170%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    0 12px 30px -18px rgba(97, 94, 166, 0.4);
+}
+
+/* Violet accent pill — glossy jelly-glass call-to-action, like the reference
+ * "Button": bright specular band on top, deeper glow pooling at the bottom. */
 .accent-pill {
   border-radius: 9999px;
-  border: 1px solid rgba(255, 255, 255, 0.55);
-  background: linear-gradient(135deg, #c1abfa 0%, #9d78f5 55%, #8b5cf6 100%);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.5) 0%,
+      rgba(255, 255, 255, 0.14) 42%,
+      rgba(255, 255, 255, 0) 62%
+    ),
+    linear-gradient(
+      135deg,
+      rgba(198, 170, 251, 0.92) 0%,
+      rgba(154, 113, 246, 0.92) 55%,
+      rgba(134, 88, 244, 0.94) 100%
+    );
   color: #ffffff;
+  -webkit-backdrop-filter: blur(10px) saturate(160%);
+  backdrop-filter: blur(10px) saturate(160%);
+  text-shadow: 0 1px 2px rgba(76, 29, 149, 0.35);
   box-shadow:
-    0 14px 30px -12px rgba(139, 92, 246, 0.55),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+    inset 0 1px 1px rgba(255, 255, 255, 0.9),
+    inset 0 -8px 16px rgba(109, 63, 233, 0.5),
+    0 16px 32px -12px rgba(139, 92, 246, 0.65);
 }
 
 @layer base {

--- a/src/features/about/components/BeyondWork.tsx
+++ b/src/features/about/components/BeyondWork.tsx
@@ -15,8 +15,8 @@ export const BeyondWork = memo(() => {
 
       <ScrollAnimationWrapper animation="fadeInUp" delay={300}>
         <div className="mx-auto max-w-4xl">
-          <div className="rounded-3xl bg-gradient-to-r from-orange-300 to-red-300 p-[1px]">
-            <div className="rounded-3xl bg-white/45 p-8 md:p-10">
+          <div className="rounded-3xl">
+            <div className="glass-panel rounded-3xl p-8 md:p-10">
               <div className="text-center">
                 <p className="text-ink-soft text-lg leading-relaxed md:text-xl">
                   &ldquo;When I&apos;m not coding, you&apos;ll probably find me hiking scenic

--- a/src/features/about/components/CoreStrengths.tsx
+++ b/src/features/about/components/CoreStrengths.tsx
@@ -15,11 +15,11 @@ export const CoreStrengths = memo(() => {
 
       <ScrollAnimationWrapper animation="fadeInUp" delay={300}>
         <div className="mx-auto max-w-6xl">
-          <div className="rounded-3xl bg-gradient-to-r from-purple-300 to-pink-300 p-[1px]">
-            <div className="rounded-3xl bg-white/45 p-8 md:p-10">
+          <div className="rounded-3xl">
+            <div className="glass-panel rounded-3xl p-8 md:p-10">
               <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
                 {/* Backend Architecture & APIs */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🏗️</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Backend Architecture & APIs</h4>
@@ -32,7 +32,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Frontend Integration Skills */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🌐</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Frontend Integration Skills</h4>
@@ -44,7 +44,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* DevOps & Cloud Integration */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🚀</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">DevOps & Cloud Integration</h4>
@@ -56,7 +56,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* AI-Assisted Development */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🤖</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">AI-Assisted Development</h4>
@@ -68,7 +68,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Database & Architecture */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🗄️</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Database & Architecture</h4>
@@ -80,7 +80,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Messaging & Integration */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🔄</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Messaging & Integration</h4>
@@ -92,7 +92,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Quality Assurance */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🧪</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Quality Assurance</h4>
@@ -103,7 +103,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Communication */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">💬</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Communication</h4>
@@ -115,7 +115,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Continuous Learning */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🚀</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Continuous Learning</h4>
@@ -127,7 +127,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Team Dynamics */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">🤝</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Team Dynamics</h4>
@@ -138,7 +138,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Clean Architecture Patterns */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">📐</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Clean Architecture Patterns</h4>
@@ -150,7 +150,7 @@ export const CoreStrengths = memo(() => {
                 </div>
 
                 {/* Performance Optimization */}
-                <div className="flex items-start gap-3 rounded-2xl bg-white/45 p-6 shadow-md">
+                <div className="glass-panel flex items-start gap-3 rounded-2xl p-6">
                   <span className="mt-1 text-2xl">⚡</span>
                   <div>
                     <h4 className="text-ink mb-2 font-semibold">Performance Optimization</h4>

--- a/src/features/about/components/PersonalIntroduction.tsx
+++ b/src/features/about/components/PersonalIntroduction.tsx
@@ -10,8 +10,8 @@ export const PersonalIntroduction = memo(() => {
   return (
     <ScrollAnimationWrapper animation="fadeInUp" delay={150}>
       <div className="mx-auto mt-12 max-w-4xl">
-        <div className="rounded-3xl bg-gradient-to-r from-violet-500 to-sky-500 p-[1px]">
-          <div className="rounded-3xl bg-white/45 p-8 md:p-10">
+        <div className="rounded-3xl">
+          <div className="glass-panel rounded-3xl p-8 md:p-10">
             <div className="flex flex-col gap-6 md:gap-8">
               <div className="space-y-4">
                 <h3 className="bg-gradient-to-r from-violet-500 to-sky-500 bg-clip-text text-xl font-semibold text-transparent md:text-2xl">

--- a/src/features/contact/components/ContactModal.tsx
+++ b/src/features/contact/components/ContactModal.tsx
@@ -192,7 +192,7 @@ export const ContactModal = ({ isOpen, onClose }: IContactModalProps) => {
 
   return (
     <Modal isOpen={isOpen} onClose={handleCancel}>
-      <div className="relative overflow-hidden rounded-2xl bg-white shadow-2xl">
+      <div className="glass-panel-solid relative overflow-hidden rounded-2xl">
         {/* Background texture */}
         <div
           className="absolute inset-0 opacity-5"

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -297,10 +297,7 @@ export const Header = () => {
 
   return (
     <>
-      <header
-        className="fixed top-0 z-10 w-full border-b border-white/50 bg-white/25 backdrop-blur-xl"
-        role="banner"
-      >
+      <header className="glass-chrome fixed top-0 z-10 w-full" role="banner">
         <div
           className={`flex w-full items-center px-4 pt-8 pb-4 md:px-24 ${showMobileUI ? "justify-between" : "justify-center"}`}
         >

--- a/src/sections/Tape.tsx
+++ b/src/sections/Tape.tsx
@@ -70,7 +70,7 @@ export const TapeSection = () => {
   return (
     <section id="tape">
       <ScrollAnimationWrapper animation="fadeIn" className="overflow-x-clip py-16 lg:py-24">
-        <div className="-mx-1 -rotate-3 bg-gradient-to-r from-violet-400 to-sky-400">
+        <div className="glass-panel -mx-1 -rotate-3">
           <div className="flex [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
             <div className="flex flex-none animate-[move-left_30s_linear_infinite] gap-4 py-3 pr-4 will-change-transform hover:[animation-play-state:paused]">
               {[0, 1].map((repeat) => (
@@ -81,8 +81,8 @@ export const TapeSection = () => {
                       className="inline-flex items-center gap-4"
                       aria-hidden={repeat === 1}
                     >
-                      <span className="text-sm font-extrabold text-white uppercase">{word}</span>
-                      <StarIcon className="size-6 -rotate-12 text-white" />
+                      <span className="text-ink text-sm font-extrabold uppercase">{word}</span>
+                      <StarIcon className="size-6 -rotate-12 text-violet-400" />
                     </div>
                   ))}
                 </Fragment>


### PR DESCRIPTION
## Summary

The glass surfaces rendered as near-opaque frosted white cards instead of the transparent "bubble" liquid glass in the reference design. This reworks the whole glass system so every surface reads as real transparent glass:

- **`glass-panel` / `glass-pill`** — see-through fills (4–48% white) with a diagonal specular streak, backdrop blur + saturation, a bright refractive rim (inset bevels on every edge), and an interior glow suggesting slab thickness
- **`accent-pill`** — glossy jelly-glass violet: specular band on top, violet glow pooling at the bottom
- **`glass-chrome`** — new class for the fixed header bar
- **`liquid-bg`** — stronger pastel saturation (lavender/pink/ice-blue) so the transparency is actually visible through the panels
- **`glass-panel-solid`** — fully opaque fill: the stacked sticky project cards ghost the card underneath at any alpha, so their glass look comes from the rim + sheen instead
- About tiles, contact modal, and the tech tape ribbon now use the glass system instead of flat white/gradient fills
- `backdrop-filter` declared `-webkit-` first so the CSS minifier keeps both the prefixed and unprefixed forms (Safari + Firefox)

## Verification

- Built with the post-build `@layer` flattening pass (`@layer left: 0`)
- Screenshotted in Chromium and WebKit (Safari engine) at iPhone (390px) and desktop (1280px) sizes across hero, projects, about, testimonials, contact, and footer — no ghosting on stacked cards, readable text everywhere, glass blur confirmed in WebKit
- ESLint and Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB)_