### PR TITLE
Fix invisible mobile menu icon and make the language toggle a true switch

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,10 @@
   color: var(--ink-faint);
 }
 
+.bg-ink {
+  background-color: var(--ink);
+}
+
 /* Pastel liquid backdrop: lavender / pink / ice blue, slowly drifting.
  * The gradients live on a fixed pseudo-element instead of the body with
  * background-attachment: fixed, which iOS Safari does not render. */

--- a/src/components/client/ui/LanguageSwitcher.tsx
+++ b/src/components/client/ui/LanguageSwitcher.tsx
@@ -3,120 +3,88 @@
 import { localeConfig, type Locale } from "@/i18n/config";
 import { useLocale } from "next-intl";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { logger } from "@/shared/utils";
 
 interface LanguageSwitcherProps {
   className?: string;
 }
 
+const LOCALES: Locale[] = ["en", "de"];
+
+/**
+ * LanguageSwitcher
+ *
+ * Fixed-order segmented toggle (EN | DE) with a sliding knob. The two
+ * languages never swap positions — only the highlight moves, like a native
+ * switch control. The knob slides optimistically on tap for instant
+ * feedback, then the locale swaps in place via soft client-side navigation
+ * (no full reload, scroll preserved).
+ */
 export const LanguageSwitcher = ({ className = "" }: LanguageSwitcherProps) => {
   const locale = useLocale() as Locale;
   const router = useRouter();
   const pathname = usePathname();
-  const [isToggling, setIsToggling] = useState(false);
+  // Locale we are navigating to; drives the knob before the route updates.
+  const [pendingLocale, setPendingLocale] = useState<Locale | null>(null);
 
-  // Handle language toggle
-  const handleLocaleToggle = () => {
-    if (isToggling) return; // Prevent double clicks
+  // Current locale from the pathname, with the hook value as backup.
+  const pathLocale = pathname.split("/")[1];
+  const routeLocale: Locale = pathLocale === "de" || pathLocale === "en" ? pathLocale : locale;
+  const activeLocale: Locale = pendingLocale ?? routeLocale;
 
-    setIsToggling(true);
+  // Once the route has caught up with the optimistic knob, clear the override.
+  useEffect(() => {
+    if (pendingLocale && routeLocale === pendingLocale) {
+      setPendingLocale(null);
+    }
+  }, [pendingLocale, routeLocale]);
+
+  const switchTo = (newLocale: Locale) => {
+    if (newLocale === activeLocale) return;
+
+    setPendingLocale(newLocale);
 
     try {
-      // Get current locale from pathname as backup
-      const pathLocale = pathname.split("/")[1];
-      const currentLocale = pathLocale === "de" || pathLocale === "en" ? pathLocale : locale;
-
-      // Toggle between English and German
-      const newLocale: Locale = currentLocale === "en" ? "de" : "en";
-
-      // Extract the path without the locale prefix
       const pathWithoutLocale = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, "") || "/";
-
-      // Navigate to the new locale with the same path
-      const newPath = `/${newLocale}${pathWithoutLocale}`;
-
-      // Debug logging
-      if (process.env.NODE_ENV === "development") {
-        logger.debug("Language Switch Debug", {
-          hookLocale: locale,
-          pathLocale,
-          currentLocale,
-          newLocale,
-          currentPathname: pathname,
-          pathWithoutLocale,
-          newPath,
-        });
-      }
-
-      // Client-side navigation swaps the locale in place — no full page
-      // reload, no white flash, scroll position preserved.
-      router.replace(newPath, { scroll: false });
-
-      // Reset toggle state after navigation
-      setTimeout(() => setIsToggling(false), 500);
+      router.replace(`/${newLocale}${pathWithoutLocale}`, { scroll: false });
     } catch (error) {
       logger.error("Language switch error", error as Error);
-      setIsToggling(false);
+      setPendingLocale(null);
     }
   };
 
-  // Get current locale from pathname as backup for UI display
-  const pathLocale = pathname.split("/")[1];
-  const displayLocale: Locale = pathLocale === "de" || pathLocale === "en" ? pathLocale : locale;
-  const currentLocaleConfig = localeConfig[displayLocale];
-  const targetLocale: Locale = displayLocale === "en" ? "de" : "en";
-  const targetLocaleConfig = localeConfig[targetLocale];
+  const activeIndex = LOCALES.indexOf(activeLocale);
 
   return (
     <div className={`glass-pill p-0.5 ${className}`}>
-      <button
-        onClick={handleLocaleToggle}
-        disabled={isToggling}
-        className="group text-ink relative flex items-center gap-3 rounded-full px-4 py-2 text-sm font-medium transition-colors duration-200 hover:bg-white/40 focus:ring-2 focus:ring-violet-300 focus:outline-none disabled:opacity-50"
-        aria-label={`Switch to ${targetLocaleConfig.name}`}
-        title={`Switch to ${targetLocaleConfig.name}`}
-      >
-        {/* Current Language - Highlighted with Header Style */}
-        <div className="text-ink flex items-center gap-2 rounded-full bg-white/85 px-3 py-1.5 shadow-sm transition-colors duration-200 hover:bg-white">
-          <span className="text-base">{currentLocaleConfig.flag}</span>
-          <span className="hidden font-semibold sm:block">{currentLocaleConfig.name}</span>
-          <span className="font-semibold sm:hidden">{displayLocale.toUpperCase()}</span>
-        </div>
-
-        {/* Toggle Arrow with Animation */}
-        <div className="relative">
-          <svg
-            className={`h-4 w-4 transition-transform duration-300 ${
-              isToggling ? "scale-110 rotate-180" : "group-hover:translate-x-0.5"
-            }`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M13 7l5 5m0 0l-5 5m5-5H6"
-            />
-          </svg>
-        </div>
-
-        {/* Target Language - Subdued */}
-        <div className="text-ink-soft flex items-center gap-2 rounded-full px-3 py-1.5 transition-colors duration-200 hover:bg-white/50">
-          <span className="text-base transition-all duration-200">{targetLocaleConfig.flag}</span>
-          <span className="hidden font-medium sm:block">{targetLocaleConfig.name}</span>
-          <span className="font-medium sm:hidden">{targetLocale.toUpperCase()}</span>
-        </div>
-
-        {/* Loading Indicator */}
-        {isToggling && (
-          <div className="absolute inset-0 flex items-center justify-center rounded-full bg-white/40 backdrop-blur-sm">
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-violet-200 border-t-violet-500" />
-          </div>
-        )}
-      </button>
+      <div className="relative grid grid-cols-2" role="group" aria-label="Language">
+        {/* Sliding knob — one segment wide, glides to the active language. */}
+        <span
+          aria-hidden="true"
+          className="text-ink absolute inset-y-0 left-0 w-1/2 rounded-full bg-white/85 shadow-sm transition-transform duration-300 ease-out"
+          style={{ transform: `translateX(${activeIndex * 100}%)` }}
+        />
+        {LOCALES.map((code) => {
+          const config = localeConfig[code];
+          const isActive = code === activeLocale;
+          return (
+            <button
+              key={code}
+              onClick={() => switchTo(code)}
+              className={`relative z-10 flex cursor-pointer items-center justify-center gap-2 rounded-full px-4 py-1.5 text-sm transition-colors duration-300 ${
+                isActive ? "text-ink font-semibold" : "text-ink-soft hover:text-ink font-medium"
+              }`}
+              aria-pressed={isActive}
+              aria-label={`Switch to ${config.name}`}
+              title={config.name}
+            >
+              <span className="text-base">{config.flag}</span>
+              <span>{code.toUpperCase()}</span>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes the two UI bugs reported on the responsive layout:

1. **Invisible mobile menu icon** — the hamburger button's three bars used a `bg-ink` utility class that was never defined in `globals.css`, so they rendered with no background at all. The `.bg-ink` utility is now defined alongside the other ink color utilities, making the menu icon visible (slate-blue bars on the glass header).

2. **Buggy language toggle** — the switcher rendered "current → target", so EN and DE swapped positions after every switch and the control looked like it reset with the selected language always first. It's rebuilt as a fixed-order **EN | DE** segmented toggle: the two languages never move, only the white knob slides between them. The knob moves optimistically on tap for instant feedback, and the locale still swaps in place via soft client-side navigation (`router.replace`, no reload, scroll preserved).

## Verification

- Interactively tested at iPhone size (390px) in headless Chromium: hamburger visible, drawer opens/closes, tapping DE slides the knob and soft-navigates to `/de` (German content, EN stays left / DE stays right), tapping EN returns to `/en`
- ESLint, Prettier, and `tsc --noEmit` clean; production build with the CSS flattening pass succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB)_