### PR TITLE
Photo thumbnail in drawer + fix Vercel native deployments

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -48,8 +48,9 @@ Thumbs.db
 docker-compose*.yml
 Dockerfile*
 
-# Scripts (build-time only)
-scripts/
+# Shell scripts (never needed on Vercel). The scripts/ directory MUST be
+# uploaded: `npm run build` runs ON Vercel and calls
+# scripts/flatten-css-layers.mjs as its final step.
 *.sh
 
 # Documentation (not needed for runtime)
@@ -63,11 +64,11 @@ sonar-project.properties
 # Test artifacts
 act-artifacts/
 
-# Linting configs
+# Linting configs (postcss.config.* is NOT ignored — the Vercel build needs
+# it for Tailwind to process the stylesheet)
 .eslintrc*
 .prettierrc*
 eslint.config.*
-postcss.config.*
 
 # Workspace files
 *.code-workspace

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -8,6 +8,8 @@ import { logger } from "@/shared/utils";
 import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useLocale } from "next-intl";
 import Link from "next/link";
+import Image from "next/image";
+import ProfilePhoto from "@/assets/images/me.jpg";
 
 interface HeaderOption {
   title: string;
@@ -371,7 +373,14 @@ export const Header = () => {
         >
           {/* Drawer header */}
           <div className="flex items-center justify-between border-b border-white/50 p-6">
-            <h2 className="text-ink text-xl font-semibold">Portfolio</h2>
+            <Image
+              src={ProfilePhoto}
+              alt="Muhammad Ahmed Shehzad"
+              width={44}
+              height={44}
+              className="size-11 rounded-full border border-white/70 object-cover shadow-sm"
+              priority={false}
+            />
             <button
               onClick={() => setIsMobileMenuOpen(false)}
               className="flex h-10 w-10 items-center justify-center rounded-full transition-colors hover:bg-white/50"

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -9,7 +9,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { useLocale } from "next-intl";
 import Link from "next/link";
 import Image from "next/image";
-import ProfilePhoto from "@/assets/images/me.jpg";
+import ProfilePhoto from "@/assets/images/me-3d.jpg";
 
 interface HeaderOption {
   title: string;


### PR DESCRIPTION
## Summary

1. **Drawer thumbnail** — replaces the "Portfolio" text in the mobile drawer header with a circular thumbnail of the professional gray-background headshot (`me-3d.jpg`), 44px, `rounded-full` with a subtle white border, rendered via `next/image`.

2. **Fix Vercel native git deployments** (failed on every commit until now) — the build died with `Cannot find module '/vercel/path0/scripts/flatten-css-layers.mjs'` because `.vercelignore` excluded `scripts/` and `postcss.config.*` from the files uploaded to Vercel. But `npm run build` executes **on** Vercel: the flatten pass is its final step and the PostCSS config drives Tailwind. Both are now uploaded; shell scripts (`*.sh`) stay excluded.

## Verification

- Drawer screenshotted at iPhone size in headless Chromium: circular professional photo in place of the text
- Local production build + CSS flatten pass succeed; ESLint/Prettier clean
- The Vercel preview build on this PR's latest commit is the live test of the `.vercelignore` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB