### PR TITLE
Flatten CSS cascade layers inside the PostCSS pipeline

### DIFF
--- a/postcss-flatten-layers.cjs
+++ b/postcss-flatten-layers.cjs
@@ -1,0 +1,35 @@
+/**
+ * PostCSS plugin: unwrap CSS cascade layers.
+ *
+ * Tailwind v4 wraps everything in `@layer` blocks, which some older iOS
+ * Safari versions mishandle — they drop every layered rule while unlayered
+ * rules keep applying, collapsing the layout. Tailwind's output is already
+ * ordered properties -> theme -> base -> utilities, so hoisting rules out of
+ * their layers preserves precedence via source order and works on any engine.
+ *
+ * Running this inside the PostCSS pipeline (after Tailwind) means every
+ * build path — local, GitHub Actions `vercel build`, and Vercel's native git
+ * deployments — emits flattened CSS. scripts/flatten-css-layers.mjs stays as
+ * an idempotent post-build safety net.
+ */
+module.exports = () => ({
+  postcssPlugin: "flatten-cascade-layers",
+  OnceExit(root) {
+    // Re-walk until stable: replacing an at-rule with its children can
+    // surface nested `@layer` blocks the current pass does not visit.
+    for (;;) {
+      let found = false;
+      root.walkAtRules("layer", (atRule) => {
+        found = true;
+        if (atRule.nodes && atRule.nodes.length > 0) {
+          atRule.replaceWith(atRule.nodes);
+        } else {
+          atRule.remove(); // bare `@layer a, b;` statements
+        }
+      });
+      if (!found) break;
+    }
+  },
+});
+
+module.exports.postcss = true;

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,15 @@
+import { join } from "node:path";
+
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},
     autoprefixer: {},
+    // Unwrap @layer blocks so older iOS Safari (which drops layered rules)
+    // renders correctly on every deploy path. See the plugin file for detail.
+    // Turbopack re-evaluates this config from inside .next, so the plugin is
+    // addressed absolutely from the project root (cwd during builds) rather
+    // than relative to this file.
+    [join(process.cwd(), "postcss-flatten-layers.cjs")]: {},
   },
 };
 


### PR DESCRIPTION
## Summary

After the `.vercelignore` fix (#111), production is deployed by **two** pipelines — the GitHub Actions release workflow and Vercel's native git integration — and the domain serves whichever finished last. The native path was found serving **layered** CSS (`@layer` intact), which is exactly the old-iOS-Safari layout-collapse condition; the post-build flatten script only protects the paths that run it.

This moves the flattening into the PostCSS pipeline itself:

- `postcss-flatten-layers.cjs` — a small PostCSS plugin that unwraps all `@layer` blocks right after Tailwind emits them, so **every** build path (local, Actions `vercel build`, native Vercel) produces Safari-safe CSS by construction
- `postcss.config.mjs` — registers the plugin by absolute path from the project root, because Turbopack re-evaluates the config from inside `.next` where relative keys and `import.meta.url`-derived paths resolve wrongly
- `scripts/flatten-css-layers.mjs` stays as an idempotent post-build safety net

## Verification

- `npx next build` alone (no post-build script) now emits `@layer = 0` in all CSS chunks, with the glass theme intact
- Full `npm run build` passes; post-build flatten confirms `@layer left: 0` with zero byte changes (nothing left to do)
- Visual smoke test at iPhone size in headless Chromium: theme renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB)_