### PR TITLE
Contact emails: harden send flow, surface SMTP failure class; clean up console errors

### DIFF
--- a/src/app/[locale]/api/contact/route.ts
+++ b/src/app/[locale]/api/contact/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import nodemailer from "nodemailer";
 
+// SMTP needs the full Node.js runtime, and the two sequential sends must not
+// be cut off by the default serverless duration.
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
 interface ContactFormData {
   name: string;
   email: string;
@@ -54,6 +59,10 @@ const createTransporter = () => {
       user: process.env["SMTP_USER"],
       pass: process.env["SMTP_PASS"],
     },
+    // Fail fast instead of hanging into the serverless function timeout.
+    connectionTimeout: 10_000,
+    greetingTimeout: 10_000,
+    socketTimeout: 15_000,
   });
 };
 
@@ -151,11 +160,15 @@ const sendContactEmail = async (formData: ContactFormData): Promise<void> => {
     `,
   };
 
-  // Send both emails
-  await Promise.all([
-    transporter.sendMail(notificationEmail),
-    transporter.sendMail(confirmationEmail),
-  ]);
+  // The notification to me is the one that must succeed; the confirmation
+  // to the sender is best-effort — a bad recipient address must not make
+  // the whole submission report failure after my copy already went out.
+  await transporter.sendMail(notificationEmail);
+  try {
+    await transporter.sendMail(confirmationEmail);
+  } catch (confirmationError) {
+    console.error("Confirmation email failed (notification was sent):", confirmationError);
+  }
 };
 
 export async function POST(
@@ -225,10 +238,17 @@ export async function POST(
   } catch (error) {
     console.error("Contact form submission error:", error);
 
+    // Surface the SMTP failure class (EAUTH, ESOCKET, ETIMEDOUT, ...) —
+    // never the message, which could carry sensitive detail. This is what
+    // lets us tell a revoked app password apart from a blocked connection
+    // without access to the server logs.
+    const errorCode =
+      error && typeof error === "object" && "code" in error ? String(error.code) : "UNKNOWN";
+
     return NextResponse.json(
       {
         success: false,
-        message: "Sorry, there was an error sending your message. Please try again later.",
+        message: `Sorry, there was an error sending your message. Please try again later. (${errorCode})`,
       },
       { status: 500 }
     );

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -215,8 +215,16 @@ export default async function LocaleLayout({ children, params }: LocaleLayoutPro
             <QueryProvider>{children}</QueryProvider>
           </ErrorBoundaryWrapper>
         </NextIntlClientProvider>
-        <SpeedInsights />
-        <Analytics />
+        {/* Vercel's injected scripts 404 (and log console errors on every
+         * page view) unless Speed Insights / Web Analytics are enabled for
+         * the project in the Vercel dashboard. Set ENABLE_VERCEL_ANALYTICS=1
+         * there after enabling both features to mount them. */}
+        {process.env["ENABLE_VERCEL_ANALYTICS"] === "1" && (
+          <>
+            <SpeedInsights />
+            <Analytics />
+          </>
+        )}
       </body>
     </html>
   );

--- a/src/components/client/ui/Modal.tsx
+++ b/src/components/client/ui/Modal.tsx
@@ -9,9 +9,11 @@ interface IModalProps {
   children: ReactNode;
   isOpen: boolean;
   onClose: () => void;
+  /** Accessible name for the dialog. */
+  label?: string;
 }
 
-export const Modal = ({ children, isOpen, onClose }: IModalProps) => {
+export const Modal = ({ children, isOpen, onClose, label = "Dialog" }: IModalProps) => {
   const handleEscape = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -65,6 +67,7 @@ export const Modal = ({ children, isOpen, onClose }: IModalProps) => {
           <dialog
             open
             aria-modal="true"
+            aria-label={label}
             className="relative z-10 mx-4 w-full max-w-lg bg-transparent"
           >
             <motion.div

--- a/src/components/client/ui/Portrait3D.tsx
+++ b/src/components/client/ui/Portrait3D.tsx
@@ -88,6 +88,10 @@ export const Portrait3D = memo(
         scene.add(keyLight);
 
         const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+        // Don't fetch/print shader program info logs: ANGLE's D3D compiler
+        // emits harmless X4122 double-precision warnings for the glass
+        // material's transmission shader, spamming the console on Windows.
+        renderer.debug.checkShaderErrors = false;
         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         renderer.setSize(container.clientWidth, container.clientHeight);
         renderer.domElement.style.position = "absolute";

--- a/src/features/contact/components/ContactModal.tsx
+++ b/src/features/contact/components/ContactModal.tsx
@@ -191,7 +191,7 @@ export const ContactModal = ({ isOpen, onClose }: IContactModalProps) => {
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={handleCancel}>
+    <Modal isOpen={isOpen} onClose={handleCancel} label="Contact form">
       <div className="glass-panel relative overflow-hidden rounded-3xl">
         {/* Background texture */}
         <div


### PR DESCRIPTION
## Summary

Two commits:

### 1. Contact email flow — harden and diagnose

The contact form's two email flows (notification to me + templated confirmation to the sender) return a generic 500 in production while the identical build sends correctly locally — so the failure is environmental (SMTP auth or connectivity from Vercel), and the real error only lands in function logs.

- **Surface the SMTP failure class** — the error response now includes the sanitized nodemailer error code (`EAUTH`, `ESOCKET`, `ETIMEDOUT`, …), never the raw message
- **Sequential, prioritized sends** — the notification must succeed; the confirmation is best-effort (previously `Promise.all` reported total failure if either send failed)
- **Fail fast** — connection/greeting/socket timeouts; explicit `runtime = "nodejs"` and `maxDuration = 30`

### 2. Console errors on production

- **Vercel analytics 404s** — `/_vercel/insights/script.js` and `/_vercel/speed-insights/script.js` 404 (and log nosniff errors) on every page view because the features aren't enabled for the project; the components now mount only when `ENABLE_VERCEL_ANALYTICS=1` is set (to be set after enabling both features in the Vercel dashboard)
- **THREE.js X4122 warnings** — ANGLE's D3D shader compiler emits harmless double-precision warnings for the glass transmission shader on Windows; three.js no longer fetches/prints shader program info logs
- **aria-label warning** — the modal `<dialog>` now has an accessible name (`aria-label`, "Contact form" for the contact dialog)

## Verification

- Local probe with unreachable SMTP host returns `(ESOCKET)` in the 500 response as designed; nodemailer proven to bundle and connect correctly on the same build
- Production build, ESLint, and Prettier all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB