### PR TITLE
Add missing .env.example; refresh deployments for the new app password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Copy to .env.local for local development: cp .env.example .env.local
+#
+# In Vercel, set these under Project Settings -> Environment Variables for
+# the Production environment. Changes apply only to NEW deployments.
+
+# --- Email (contact form) ---------------------------------------------------
+# For Gmail, SMTP_PASS must be a 16-character app password (Google Account ->
+# Security -> 2-Step Verification -> App passwords), entered WITHOUT spaces.
+# Changing the Google account password revokes existing app passwords.
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password
+# Recipient of contact-form notifications; defaults to SMTP_USER when unset.
+CONTACT_EMAIL=
+
+# --- App --------------------------------------------------------------------
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+
+# --- Vercel Web Analytics / Speed Insights (optional) -----------------------
+# Enable both features in the Vercel dashboard first, then set to 1.
+ENABLE_VERCEL_ANALYTICS=

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 !.env.local.example
 !.env.*.example
 .env.sonar.example


### PR DESCRIPTION
## Summary

Adds the `.env.example` that the README setup instructions (`cp .env.example .env.local`) have referenced all along but which never existed. It documents the variables the app actually reads — the SMTP settings for the contact form (including the Gmail app password requirements: 16 characters, no spaces, Production scope), `CONTACT_EMAIL`, `NEXT_PUBLIC_BASE_URL`, and the optional `ENABLE_VERCEL_ANALYTICS` flag — and un-ignores the file in `.gitignore`.

Merging also creates fresh production deployments on both pipelines, picking up the newly stored Gmail app password for the contact form's email delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1v8JmXyekuRcFV3vcTukB)_